### PR TITLE
CMake: Adding full CMake support for building and testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(gherkin-cpp)
+cmake_minimum_required(VERSION 3.0)
+
+option(BUILD_SHARED_LIBS "Build shared library." OFF)
+
+LIST(APPEND GHERKIN_CPP_SRS
+        src/compiler.cpp
+        src/parser.cpp
+)
+
+ADD_LIBRARY(gherkin-cpp ${GHERKIN_CPP_SRS})
+ADD_LIBRARY(gherkin-cpp::gherkin-cpp ALIAS gherkin-cpp)
+
+TARGET_INCLUDE_DIRECTORIES(gherkin-cpp
+        PUBLIC ${PROJECT_SOURCE_DIR}/include
+)
+
+ADD_SUBDIRECTORY(libs/fmem)
+TARGET_LINK_LIBRARIES(gherkin-cpp PUBLIC fmem)
+
+ADD_SUBDIRECTORY(libs/gherkin-c)
+TARGET_LINK_LIBRARIES(gherkin-cpp PUBLIC gherkin)
+
+ADD_SUBDIRECTORY(test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,14 @@
+ADD_EXECUTABLE(gherkin-cpp-test main.cpp)
+TARGET_LINK_LIBRARIES(gherkin-cpp-test PUBLIC gherkin-cpp)
+
+ADD_CUSTOM_TARGET(gherkin-cpp-test.run DEPENDS testgherkin-cpp-)
+
+FILE(COPY testdata DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+ADD_CUSTOM_COMMAND(
+        TARGET gherkin-cpp-test.run
+        POST_BUILD
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/run_tests.py
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        COMMENT "Running the tests"
+)

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -1,0 +1,64 @@
+#!/usr/bin/python3
+import subprocess
+import os
+
+# prevent stack-trace on ctrl+c
+import signal
+import sys
+signal.signal(signal.SIGINT, lambda x, y: sys.exit(0))
+
+import filecmp
+
+class bcolors:
+  OKGREEN = '\033[32m'
+  FAIL = '\033[91m'
+  ENDC = '\033[0m'
+
+targets = []
+
+# collect the list of all tests
+for root, dirs, files in os.walk("."):
+    for file in files:
+        if file.endswith(".feature"):
+            targets.append(os.path.join(root, file))
+
+overal_result = True
+
+for target in targets:
+    #print(target)
+    target_result = target+".result"
+    outfile = open(target_result, "w")
+    run_result = subprocess.run(["valgrind", "--leak-check=full", "--error-exitcode=-1", "./test", target], stdout=outfile, stderr=subprocess.DEVNULL)
+    #print(run_result.returncode)
+
+
+    # quick hack to keep the .out files untouched but still run from the test folder
+    fin = open(target_result, "rt")
+    data = fin.read()
+    data = data.replace('"uri":"./testdata/', '"uri":"test/testdata/')
+    fin.close()
+    fin = open(target_result, "wt")
+    fin.write(data)
+    fin.close()
+
+    target_out = target + ".out"
+    comp = filecmp.cmp(target_out, target_result)
+    #print("Test run result: " + str(comp))
+
+    fixed_target_string = "{0:>70}".format(target)
+    print(fixed_target_string + " -> ", end='', flush=True)
+
+    if comp == True:
+        colored_status_code = bcolors.OKGREEN + 'OK' + bcolors.ENDC
+    else:
+        colored_status_code = bcolors.FAIL + 'FAIL' + bcolors.ENDC
+        overal_result = False
+    print(colored_status_code)
+
+if overal_result == True:
+    os._exit(0)
+else:
+    print("Compare the *.feature.out to the *.feature.result for each failed test")
+    print("----------------------------------------------------------------------")
+    print("At least one test failed, so this script exits with an error (exit code 1)")
+    os._exit(1)


### PR DESCRIPTION
This PR is adding full CMake support. The only thing left do do is to figure out why 3 of the tests fail:

# Motivation

We want to be able to do our of source builds and since we use lots of CMake already this was the only submodule which still forced us to Makefiles. 

Also we can now use ninja to build all our source code.

It is now easy to include this code base using CMakeLists.txt from the parent:

add_subdirectory(libs/gherkin-cpp)
link_libraries(PUBLIC gherkin-cpp::gherkin-cpp)

The `link_libraries` will then also add the headers to the search path.

# Tests

What test(s) still fail:

- ./testdata/good/incomplete_scenario.feature
- ./testdata/good/several_examples.feature
- ./testdata/good/incomplete_scenario_outline.feature

All other work! But I think that I did not cause those fails. Probably the tests need updates...

```
$ make test.run
[  3%] Built target fmem
[ 91%] Built target gherkin
[ 96%] Built target gherkin-cpp
[100%] Built target test
Running the tests
                        ./testdata/good/example_token_multiple.feature -> OK
                                    ./testdata/good/background.feature -> OK
                   ./testdata/good/scenario_outlines_with_tags.feature -> OK
                           ./testdata/good/incomplete_scenario.feature -> FAIL
                                    ./testdata/good/datatables.feature -> OK
                                    ./testdata/good/i18n_emoji.feature -> OK
                          ./testdata/good/incomplete_feature_3.feature -> OK
                   ./testdata/good/scenario_outline_no_newline.feature -> OK
                                       ./testdata/good/minimal.feature -> OK
                            ./testdata/good/spaces_in_language.feature -> OK
                                    ./testdata/good/docstrings.feature -> OK
                                 ./testdata/good/escaped_pipes.feature -> OK
                                          ./testdata/good/tags.feature -> OK
                          ./testdata/good/incomplete_feature_2.feature -> OK
                       ./testdata/good/incomplete_background_1.feature -> OK
                              ./testdata/good/several_examples.feature -> FAIL
                                      ./testdata/good/language.feature -> OK
                                       ./testdata/good/i18n_no.feature -> OK
                     ./testdata/good/example_tokens_everywhere.feature -> OK
                                  ./testdata/good/descriptions.feature -> OK
                   ./testdata/good/incomplete_scenario_outline.feature -> FAIL
                              ./testdata/good/scenario_outline.feature -> OK
                       ./testdata/good/incomplete_background_2.feature -> OK
                          ./testdata/good/incomplete_feature_1.feature -> OK
                                         ./testdata/good/empty.feature -> OK
                                ./testdata/good/readme_example.feature -> OK
                                       ./testdata/good/i18n_fr.feature -> OK
                               ./testdata/bad/invalid_language.feature -> OK
                            ./testdata/bad/single_parser_error.feature -> OK
                                    ./testdata/bad/not_gherkin.feature -> OK
                        ./testdata/bad/inconsistent_cell_count.feature -> OK
                                 ./testdata/bad/unexpected_eof.feature -> OK
                         ./testdata/bad/multiple_parser_errors.feature -> OK
Compare the *.feature.out to the *.feature.result for each failed test
----------------------------------------------------------------------
At least one test failed, so this script exits with an error (exit code 1)
make[3]: *** [test/CMakeFiles/test.run.dir/build.make:62: test.run] Error 1
make[2]: *** [CMakeFiles/Makefile2:249: test/CMakeFiles/test.run.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:256: test/CMakeFiles/test.run.dir/rule] Error 2
```
